### PR TITLE
Request on cache:clear not available

### DIFF
--- a/Provider/CookieProvider.php
+++ b/Provider/CookieProvider.php
@@ -33,6 +33,10 @@ class CookieProvider extends AbstractValueProvider
      */
     protected function getValue(string $featureFlag): string
     {
+        if ($this->requestStack->getCurrentRequest() === null) {
+            return '';
+        }
+
         return (string) $this->requestStack->getCurrentRequest()->cookies->get('featureFlag_' . $featureFlag);
     }
 }

--- a/Provider/UserAgentProvider.php
+++ b/Provider/UserAgentProvider.php
@@ -57,6 +57,10 @@ class UserAgentProvider extends AbstractValueProvider
      */
     protected function getValue(string $featureFlag): string
     {
+        if ($this->requestStack->getCurrentRequest() === null) {
+            return '';
+        }
+
         return (string) $this->requestStack->getCurrentRequest()->headers->get('User-Agent');
     }
 }


### PR DESCRIPTION
Sometimes the RequestStack is not available, so we have to handle this case (in this case, the featureflags are not active through Cookie and UserAgent)