### PR TITLE
fix tree builder root node deprecation introduced with symfony 4.3

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Shopping\FeatureFlagBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -19,8 +20,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('shopping_feature_flag');
+        $treeBuilder = new TreeBuilder('shopping_feature_flag');
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fixes 
![Bildschirmfoto 2019-11-12 um 16 43 06](https://user-images.githubusercontent.com/690188/68686185-8b019e00-056b-11ea-8e9a-ed0eb2d837cb.png)
