### PR TITLE
Allow FeatureFlag to be provided in $_ENV

### DIFF
--- a/Provider/DotEnvProvider.php
+++ b/Provider/DotEnvProvider.php
@@ -16,7 +16,11 @@ class DotEnvProvider implements FeatureFlagInterface
      */
     public function isActive(string $featureFlag): bool
     {
-        return (bool) getenv($this->buildEnvName($featureFlag));
+        $dotEnvName = $this->buildEnvName($featureFlag);
+        $getEnv = (bool) getenv($dotEnvName);
+        $dotEnv = !empty($_ENV[$dotEnvName]) ? (bool) $_ENV[$dotEnvName] : false;
+
+        return $getEnv || $dotEnv;
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where getenv does not contain the values set in .env file

